### PR TITLE
remove contracts_build_directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: update-web-contracts
+update-web-contracts:
+	truffle compile --all
+	rm -rf web/src/contracts
+	cp -r build/contracts web/src/

--- a/gen_and_push.sh
+++ b/gen_and_push.sh
@@ -22,8 +22,8 @@ get_pr() {
 }
 
 extract_abi_bin() {
-  jq .abi web/src/contracts/$1.json > genfiles/$1.abi
-  jq -r .bytecode web/src/contracts/$1.json > genfiles/$1.bin
+  jq .abi build/contracts/$1.json > genfiles/$1.abi
+  jq -r .bytecode build/contracts/$1.json > genfiles/$1.bin
 }
 
 update_genfiles() {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -35,7 +35,6 @@ module.exports = {
    * $ truffle test --network <network-name>
    */
 
-  contracts_build_directory: './web/src/contracts',
   networks: {
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.


### PR DESCRIPTION
Contracts build directory is not affiliated to web folder. Some tools that use build directory don't need to know web folder like config.yml and gen_go_binding. It's better to use the default setting to make the repo structure clear.
Also added a make command to make it convenient to update contracts build for web.